### PR TITLE
Upgrade to v0.9.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 
-frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28", optional = true }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30", optional = true }
+frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
+frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 
-pallet-assets = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+pallet-assets = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 
 [dev-dependencies]
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-sp-core = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-sp-io = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
+sp-core = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
+sp-io = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ TBA
 ## Configuration
 
 ### Types
-* `Event` – The overarching event type.
+* `RuntimeEvent` – The overarching event type.
 * `Currency` – The currency type.
 * `AssetBalance` – The balance type for assets.
 * `AssetToCurrencyBalance` – A type providing conversion from the asset balance type to the currency balance type.
@@ -344,7 +344,7 @@ pub type AssetBalance = Balance;
 pub type AssetId = u32;
 
 impl pallet_assets::Config for Runtime {
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type Balance = AssetBalance;
     type AssetId = AssetId;
     type Currency = Balances;
@@ -370,7 +370,7 @@ parameter_types! {
 
 impl pallet_dex::Config for Runtime {
     type PalletId = DexPalletId;
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type AssetBalance = AssetBalance;
     type AssetToCurrencyBalance = Identity;
@@ -437,7 +437,7 @@ impl_runtime_apis! {
 ```
 
 ### Node's `chain_spec.rs`
-Add genesis configuration for assets pallet.
+Add genesis configuration for assets and dex pallets.
 ```rust
 fn testnet_genesis(
     wasm_binary: &[u8],
@@ -453,6 +453,9 @@ fn testnet_genesis(
             accounts: vec![],
             metadata: vec![],
         },
+        dex: DexConfig {
+            exchanges: vec![],
+        }
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -277,10 +277,10 @@ i.e. 'How much asset do I have to pay to get this much currency'?
 ## How to add `pallet-dex` to a node
 
 :information_source: The pallet is compatible with Substrate version
-[polkadot-v0.9.28](https://github.com/paritytech/substrate/tree/polkadot-v0.9.28).
+[polkadot-v0.9.30](https://github.com/paritytech/substrate/tree/polkadot-v0.9.30).
 
 :information_source: This section is based on
-[Substrate node template](https://github.com/substrate-developer-hub/substrate-node-template/tree/polkadot-v0.9.28).
+[Substrate node template](https://github.com/substrate-developer-hub/substrate-node-template/tree/polkadot-v0.9.30).
 Integrating `pallet-dex` with another node might look slightly different.
 
 ### Runtime's `Cargo.toml`
@@ -291,7 +291,7 @@ Add `pallet-dex`, the RPC runtime API, and `pallet-assets` (required for handlin
 version = "4.0.0-dev"
 default-features = false
 git = "https://github.com/paritytech/substrate.git"
-branch = "polkadot-v0.9.28"
+branch = "polkadot-v0.9.30"
 
 [dependencies.pallet-dex]
 version = "0.0.1"

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -16,6 +16,6 @@ jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
 
 pallet-dex-rpc-runtime-api = { version = "0.0.1", path = "./runtime-api" }
 
-sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
+sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }

--- a/rpc/runtime-api/Cargo.toml
+++ b/rpc/runtime-api/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 
 pallet-dex = { version = "0.0.1", default-features = false, path = "../.." }
-sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.30" }
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod pallet {
         type PalletId: Get<PalletId>;
 
         /// The overarching event type.
-        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The currency trait.
         type Currency: Currency<Self::AccountId>;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -26,8 +26,8 @@ impl frame_system::Config for Test {
     type BaseCallFilter = Everything;
     type BlockWeights = ();
     type BlockLength = ();
-    type Origin = Origin;
-    type Call = Call;
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
     type Index = u32;
     type BlockNumber = u32;
     type Hash = H256;
@@ -35,7 +35,7 @@ impl frame_system::Config for Test {
     type AccountId = u64;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type BlockHashCount = ConstU32<250>;
     type DbWeight = ();
     type Version = ();
@@ -52,7 +52,7 @@ impl frame_system::Config for Test {
 impl pallet_balances::Config for Test {
     type Balance = u128;
     type DustRemoval = ();
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type ExistentialDeposit = ConstU128<1>;
     type AccountStore = System;
     type WeightInfo = ();
@@ -62,7 +62,7 @@ impl pallet_balances::Config for Test {
 }
 
 impl pallet_assets::Config for Test {
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type Balance = u128;
     type AssetId = u32;
     type Currency = Balances;
@@ -84,7 +84,7 @@ parameter_types! {
 
 impl dex::Config for Test {
     type PalletId = DexPalletId;
-    type Event = Event;
+    type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type AssetBalance = u128;
     type AssetToCurrencyBalance = Identity;
@@ -160,7 +160,7 @@ pub(crate) fn last_n_events(n: usize) -> Vec<dex::Event<Test>> {
         .into_iter()
         .map(|r| r.event)
         .filter_map(|event| match event {
-            Event::Dex(inner) => Some(inner),
+            RuntimeEvent::Dex(inner) => Some(inner),
             _ => None,
         })
         .collect();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,13 @@ use frame_support::{
 #[test]
 fn create_exchange() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Dex::create_exchange(RuntimeOrigin::signed(ACCOUNT_A), ASSET_B, LIQ_TOKEN_B, 1, 1));
+        assert_ok!(Dex::create_exchange(
+            RuntimeOrigin::signed(ACCOUNT_A),
+            ASSET_B,
+            LIQ_TOKEN_B,
+            1,
+            1
+        ));
         let exchange = Dex::exchanges(ASSET_B).unwrap();
         assert_eq!(exchange.asset_id, ASSET_B);
         assert_eq!(exchange.currency_reserve, 1);
@@ -84,7 +90,14 @@ fn create_exchange_token_id_taken() {
 #[test]
 fn add_liquidity() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_B), ASSET_A, 1_000, 1_000, 1_001, 1,));
+        assert_ok!(Dex::add_liquidity(
+            RuntimeOrigin::signed(ACCOUNT_B),
+            ASSET_A,
+            1_000,
+            1_000,
+            1_001,
+            1,
+        ));
 
         let exchange = Dex::exchanges(ASSET_A).unwrap();
         assert_eq!(exchange.currency_reserve, INIT_LIQUIDITY + 1_000);
@@ -230,7 +243,14 @@ fn add_liquidity_min_liquidity_too_high() {
 #[test]
 fn remove_liquidity() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 500, 500, 500, 1,));
+        assert_ok!(Dex::remove_liquidity(
+            RuntimeOrigin::signed(ACCOUNT_A),
+            ASSET_A,
+            500,
+            500,
+            500,
+            1,
+        ));
         let exchange = Dex::exchanges(ASSET_A).unwrap();
         assert_eq!(exchange.currency_reserve, INIT_LIQUIDITY - 500);
         assert_eq!(exchange.token_reserve, INIT_LIQUIDITY - 500);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@ use frame_support::{
 #[test]
 fn create_exchange() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Dex::create_exchange(Origin::signed(ACCOUNT_A), ASSET_B, LIQ_TOKEN_B, 1, 1));
+        assert_ok!(Dex::create_exchange(RuntimeOrigin::signed(ACCOUNT_A), ASSET_B, LIQ_TOKEN_B, 1, 1));
         let exchange = Dex::exchanges(ASSET_B).unwrap();
         assert_eq!(exchange.asset_id, ASSET_B);
         assert_eq!(exchange.currency_reserve, 1);
@@ -25,7 +25,7 @@ fn create_exchange() {
 fn create_exchange_unsigned() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::create_exchange(Origin::none(), ASSET_A, LIQ_TOKEN_A, 1, 1),
+            Dex::create_exchange(RuntimeOrigin::none(), ASSET_A, LIQ_TOKEN_A, 1, 1),
             frame_support::error::BadOrigin
         );
     })
@@ -35,7 +35,7 @@ fn create_exchange_unsigned() {
 fn create_exchange_currency_amount_too_low() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::create_exchange(Origin::signed(ACCOUNT_A), ASSET_A, LIQ_TOKEN_A, 0, 1),
+            Dex::create_exchange(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, LIQ_TOKEN_A, 0, 1),
             Error::<Test>::CurrencyAmountTooLow
         );
     })
@@ -45,7 +45,7 @@ fn create_exchange_currency_amount_too_low() {
 fn create_exchange_token_amount_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::create_exchange(Origin::signed(ACCOUNT_A), ASSET_A, LIQ_TOKEN_A, 1, 0),
+            Dex::create_exchange(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, LIQ_TOKEN_A, 1, 0),
             Error::<Test>::TokenAmountIsZero
         );
     })
@@ -55,7 +55,7 @@ fn create_exchange_token_amount_zero() {
 fn create_exchange_asset_not_found() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::create_exchange(Origin::signed(ACCOUNT_A), 2137, LIQ_TOKEN_A, 1, 1),
+            Dex::create_exchange(RuntimeOrigin::signed(ACCOUNT_A), 2137, LIQ_TOKEN_A, 1, 1),
             Error::<Test>::AssetNotFound
         );
     })
@@ -65,7 +65,7 @@ fn create_exchange_asset_not_found() {
 fn create_exchange_already_exists() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::create_exchange(Origin::signed(ACCOUNT_A), ASSET_A, LIQ_TOKEN_A, 1, 1),
+            Dex::create_exchange(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, LIQ_TOKEN_A, 1, 1),
             Error::<Test>::ExchangeAlreadyExists
         );
     })
@@ -75,7 +75,7 @@ fn create_exchange_already_exists() {
 fn create_exchange_token_id_taken() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::create_exchange(Origin::signed(ACCOUNT_A), ASSET_B, LIQ_TOKEN_A, 1, 1),
+            Dex::create_exchange(RuntimeOrigin::signed(ACCOUNT_A), ASSET_B, LIQ_TOKEN_A, 1, 1),
             Error::<Test>::TokenIdTaken
         );
     })
@@ -84,7 +84,7 @@ fn create_exchange_token_id_taken() {
 #[test]
 fn add_liquidity() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Dex::add_liquidity(Origin::signed(ACCOUNT_B), ASSET_A, 1_000, 1_000, 1_001, 1,));
+        assert_ok!(Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_B), ASSET_A, 1_000, 1_000, 1_001, 1,));
 
         let exchange = Dex::exchanges(ASSET_A).unwrap();
         assert_eq!(exchange.currency_reserve, INIT_LIQUIDITY + 1_000);
@@ -107,7 +107,7 @@ fn add_liquidity() {
 fn add_liquidity_unsigned() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::none(), ASSET_A, 1_000, 1_000, 1_000, 1),
+            Dex::add_liquidity(RuntimeOrigin::none(), ASSET_A, 1_000, 1_000, 1_000, 1),
             frame_support::error::BadOrigin
         );
     })
@@ -117,7 +117,7 @@ fn add_liquidity_unsigned() {
 fn add_liquidity_deadline_passed() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 1_000, 1_000, 1_000, 0),
+            Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 1_000, 1_000, 1_000, 0),
             Error::<Test>::DeadlinePassed
         );
     })
@@ -127,7 +127,7 @@ fn add_liquidity_deadline_passed() {
 fn add_liquidity_zero_currency() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 0, 1_000, 1_000, 1),
+            Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 0, 1_000, 1_000, 1),
             Error::<Test>::CurrencyAmountIsZero
         );
     })
@@ -137,7 +137,7 @@ fn add_liquidity_zero_currency() {
 fn add_liquidity_zero_tokens() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 1_000, 1_000, 0, 1),
+            Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 1_000, 1_000, 0, 1),
             Error::<Test>::MaxTokensIsZero
         );
     })
@@ -148,7 +148,7 @@ fn add_liquidity_balance_too_low() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::add_liquidity(
-                Origin::signed(ACCOUNT_A),
+                RuntimeOrigin::signed(ACCOUNT_A),
                 ASSET_A,
                 INIT_BALANCE + 1,
                 1_000,
@@ -164,7 +164,7 @@ fn add_liquidity_balance_too_low() {
 fn add_liquidity_asset_not_found() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::signed(ACCOUNT_A), 2137, 1_000, 1_000, 1_000, 1),
+            Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_A), 2137, 1_000, 1_000, 1_000, 1),
             Error::<Test>::AssetNotFound
         );
     })
@@ -175,7 +175,7 @@ fn add_liquidity_not_enough_tokens() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::add_liquidity(
-                Origin::signed(ACCOUNT_A),
+                RuntimeOrigin::signed(ACCOUNT_A),
                 ASSET_A,
                 1_000,
                 1_000,
@@ -191,7 +191,7 @@ fn add_liquidity_not_enough_tokens() {
 fn add_liquidity_exchange_not_found() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::signed(ACCOUNT_A), ASSET_B, 1_000, 1_000, 1_000, 1),
+            Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_B, 1_000, 1_000, 1_000, 1),
             Error::<Test>::ExchangeNotFound
         );
     })
@@ -201,7 +201,7 @@ fn add_liquidity_exchange_not_found() {
 fn add_liquidity_zero_min_liquidity() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::signed(ACCOUNT_B), ASSET_A, 1_000, 0, 1_001, 1),
+            Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_B), ASSET_A, 1_000, 0, 1_001, 1),
             Error::<Test>::MinLiquidityIsZero
         );
     })
@@ -211,7 +211,7 @@ fn add_liquidity_zero_min_liquidity() {
 fn add_liquidity_max_tokens_too_low() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::signed(ACCOUNT_B), ASSET_A, 1_000, 1_000, 10, 1),
+            Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_B), ASSET_A, 1_000, 1_000, 10, 1),
             Error::<Test>::MaxTokensTooLow
         );
     })
@@ -221,7 +221,7 @@ fn add_liquidity_max_tokens_too_low() {
 fn add_liquidity_min_liquidity_too_high() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::add_liquidity(Origin::signed(ACCOUNT_B), ASSET_A, 1_000, 10_000, 1_001, 1),
+            Dex::add_liquidity(RuntimeOrigin::signed(ACCOUNT_B), ASSET_A, 1_000, 10_000, 1_001, 1),
             Error::<Test>::MinLiquidityTooHigh
         );
     })
@@ -230,7 +230,7 @@ fn add_liquidity_min_liquidity_too_high() {
 #[test]
 fn remove_liquidity() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Dex::remove_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 500, 500, 500, 1,));
+        assert_ok!(Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 500, 500, 500, 1,));
         let exchange = Dex::exchanges(ASSET_A).unwrap();
         assert_eq!(exchange.currency_reserve, INIT_LIQUIDITY - 500);
         assert_eq!(exchange.token_reserve, INIT_LIQUIDITY - 500);
@@ -255,7 +255,7 @@ fn remove_liquidity() {
 fn remove_liquidity_unsigned() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::remove_liquidity(Origin::none(), ASSET_A, 500, 500, 500, 1),
+            Dex::remove_liquidity(RuntimeOrigin::none(), ASSET_A, 500, 500, 500, 1),
             frame_support::error::BadOrigin
         );
     });
@@ -265,7 +265,7 @@ fn remove_liquidity_unsigned() {
 fn remove_liquidity_deadline_passed() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::remove_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 500, 500, 500, 0),
+            Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 500, 500, 500, 0),
             Error::<Test>::DeadlinePassed
         );
     });
@@ -275,7 +275,7 @@ fn remove_liquidity_deadline_passed() {
 fn remove_zero_liquidity() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::remove_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 0, 500, 500, 1),
+            Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 0, 500, 500, 1),
             crate::Error::<Test>::LiquidityAmountIsZero
         );
     });
@@ -285,7 +285,7 @@ fn remove_zero_liquidity() {
 fn remove_liquidity_min_currency_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::remove_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 500, 0, 500, 1),
+            Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 500, 0, 500, 1),
             crate::Error::<Test>::MinCurrencyIsZero
         );
     });
@@ -295,7 +295,7 @@ fn remove_liquidity_min_currency_zero() {
 fn remove_liquidity_min_tokens_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::remove_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 500, 500, 0, 1),
+            Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 500, 500, 0, 1),
             crate::Error::<Test>::MinTokensIsZero
         );
     });
@@ -305,7 +305,7 @@ fn remove_liquidity_min_tokens_zero() {
 fn remove_liquidity_exchange_not_found() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::remove_liquidity(Origin::signed(ACCOUNT_A), ASSET_B, 500, 500, 500, 1),
+            Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_B, 500, 500, 500, 1),
             crate::Error::<Test>::ExchangeNotFound
         );
     });
@@ -316,7 +316,7 @@ fn remove_liquidity_provider_liquidity_too_low() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::remove_liquidity(
-                Origin::signed(ACCOUNT_A),
+                RuntimeOrigin::signed(ACCOUNT_A),
                 ASSET_A,
                 INIT_LIQUIDITY + 500,
                 INIT_LIQUIDITY + 500,
@@ -332,7 +332,7 @@ fn remove_liquidity_provider_liquidity_too_low() {
 fn remove_liquidity_min_currency_too_high() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::remove_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 500, 1_500, 500, 1),
+            Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 500, 1_500, 500, 1),
             crate::Error::<Test>::MinCurrencyTooHigh
         );
     });
@@ -342,7 +342,7 @@ fn remove_liquidity_min_currency_too_high() {
 fn remove_liquidity_min_tokens_too_high() {
     new_test_ext().execute_with(|| {
         assert_noop!(
-            Dex::remove_liquidity(Origin::signed(ACCOUNT_A), ASSET_A, 500, 500, 1_500, 1),
+            Dex::remove_liquidity(RuntimeOrigin::signed(ACCOUNT_A), ASSET_A, 500, 500, 1_500, 1),
             crate::Error::<Test>::MinTokensTooHigh
         );
     });
@@ -355,7 +355,7 @@ fn currency_to_asset_fixed_input() {
         let token_amount = 498; // currency amount (500) - provider fee (0.3%) should be ~498
 
         assert_ok!(Dex::currency_to_asset(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             TradeAmount::FixedInput {
                 input_amount: curr_amount,
@@ -396,7 +396,7 @@ fn currency_to_asset_fixed_output() {
         let token_amount = 498; // currency amount (500) - provider fee (0.3%) should be ~498
 
         assert_ok!(Dex::currency_to_asset(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             TradeAmount::FixedOutput {
                 max_input: curr_amount,
@@ -435,7 +435,7 @@ fn currency_to_asset_unsigned() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::none(),
+                RuntimeOrigin::none(),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 1,
@@ -454,7 +454,7 @@ fn currency_to_asset_deadline_passed() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 1,
@@ -473,7 +473,7 @@ fn currency_to_asset_currency_amount_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 0,
@@ -492,7 +492,7 @@ fn currency_to_asset_min_tokens_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 100,
@@ -511,7 +511,7 @@ fn currency_to_asset_max_currency_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedOutput {
                     max_input: 0,
@@ -530,7 +530,7 @@ fn currency_to_asset_token_amount_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedOutput {
                     max_input: 100,
@@ -553,7 +553,7 @@ fn currency_to_asset_balance_too_low() {
         <Test as crate::Config>::Currency::make_free_balance_be(&ACCOUNT_B, 1);
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: currency_amount,
@@ -572,7 +572,7 @@ fn currency_to_asset_exchange_not_found() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_B,
                 TradeAmount::FixedInput {
                     input_amount: 1,
@@ -591,7 +591,7 @@ fn currency_to_asset_min_tokens_too_high() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 10,
@@ -610,7 +610,7 @@ fn currency_to_asset_max_currency_too_low() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedOutput {
                     max_input: 10,
@@ -629,7 +629,7 @@ fn currency_to_asset_not_enough_liquidity() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::currency_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedOutput {
                     max_input: INIT_LIQUIDITY + 1000,
@@ -650,7 +650,7 @@ fn currency_to_asset_transfer() {
         let token_amount = 498; // currency amount (500) - provider fee (0.3%) should be ~498
 
         assert_ok!(Dex::currency_to_asset(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             TradeAmount::FixedInput {
                 input_amount: curr_amount,
@@ -683,7 +683,7 @@ fn asset_to_currency_fixed_input() {
         let curr_amount = 498; // token amount (500) - provider fee (0.3%) should be ~498
 
         assert_ok!(Dex::asset_to_currency(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             TradeAmount::FixedInput {
                 input_amount: token_amount,
@@ -722,7 +722,7 @@ fn asset_to_currency_unsigned() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::none(),
+                RuntimeOrigin::none(),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 1,
@@ -741,7 +741,7 @@ fn asset_to_currency_deadline_passed() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 1,
@@ -760,7 +760,7 @@ fn asset_to_currency_min_currency_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 100,
@@ -779,7 +779,7 @@ fn asset_to_currency_token_amount_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 0,
@@ -798,7 +798,7 @@ fn asset_to_currency_currency_amount_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedOutput {
                     max_input: 100,
@@ -817,7 +817,7 @@ fn asset_to_currency_max_tokens_is_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedOutput {
                     max_input: 0,
@@ -840,7 +840,7 @@ fn asset_to_currency_not_enough_tokens() {
         <Test as crate::Config>::Assets::burn_from(ASSET_A, &ACCOUNT_B, INIT_BALANCE).unwrap();
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: token_amount,
@@ -859,7 +859,7 @@ fn asset_to_currency_exchange_not_found() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_B,
                 TradeAmount::FixedInput {
                     input_amount: 1,
@@ -878,7 +878,7 @@ fn asset_to_currency_min_currency_too_high() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedInput {
                     input_amount: 10,
@@ -897,7 +897,7 @@ fn asset_to_currency_max_tokens_too_low() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedOutput {
                     output_amount: 50,
@@ -916,7 +916,7 @@ fn asset_to_currency_not_enough_liquidity() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_currency(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 TradeAmount::FixedOutput {
                     output_amount: INIT_LIQUIDITY + 1000,
@@ -937,7 +937,7 @@ fn asset_to_currency_transfer() {
         let curr_amount = 498; // token amount (500) - provider fee (0.3%) should be ~498
 
         assert_ok!(Dex::asset_to_currency(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             TradeAmount::FixedInput {
                 input_amount: token_amount,
@@ -970,7 +970,7 @@ fn asset_to_currency_fixed_output() {
         let curr_amount = 498; // token amount (500) - provider fee (0.3%) should be ~498
 
         assert_ok!(Dex::asset_to_currency(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             TradeAmount::FixedOutput {
                 output_amount: curr_amount,
@@ -1008,7 +1008,7 @@ fn asset_to_currency_fixed_output() {
 fn asset_to_asset_fixed_input() {
     new_test_ext().execute_with(|| {
         Dex::create_exchange(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             LIQ_TOKEN_B,
             INIT_LIQUIDITY,
@@ -1021,7 +1021,7 @@ fn asset_to_asset_fixed_input() {
         let bought_token_amount = 496; // currency amount (498) - provider fee (0.3%) should be ~496
 
         assert_ok!(Dex::asset_to_asset(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             ASSET_B,
             TradeAmount::FixedInput {
@@ -1087,7 +1087,7 @@ fn asset_to_asset_unsigned() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::none(),
+                RuntimeOrigin::none(),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedInput {
@@ -1107,7 +1107,7 @@ fn asset_to_asset_deadline_passed() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedInput {
@@ -1127,7 +1127,7 @@ fn asset_to_asset_sold_token_amount_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedInput {
@@ -1147,7 +1147,7 @@ fn asset_to_asset_min_bought_tokens_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedInput {
@@ -1167,7 +1167,7 @@ fn asset_to_asset_max_sold_tokens_amount_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedOutput {
@@ -1187,7 +1187,7 @@ fn asset_to_asset_output_bought_token_amount_zero() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedOutput {
@@ -1206,7 +1206,7 @@ fn asset_to_asset_output_bought_token_amount_zero() {
 fn asset_to_asset_not_enough_tokens() {
     new_test_ext().execute_with(|| {
         Dex::create_exchange(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             LIQ_TOKEN_B,
             INIT_LIQUIDITY,
@@ -1222,7 +1222,7 @@ fn asset_to_asset_not_enough_tokens() {
 
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedInput {
@@ -1242,7 +1242,7 @@ fn asset_to_asset_sold_asset_exchange_not_found() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_B,
                 ASSET_A,
                 TradeAmount::FixedInput {
@@ -1262,7 +1262,7 @@ fn asset_to_asset_bought_asset_exchange_not_found() {
     new_test_ext().execute_with(|| {
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedInput {
@@ -1281,7 +1281,7 @@ fn asset_to_asset_bought_asset_exchange_not_found() {
 fn asset_to_asset_min_bought_tokens_too_high() {
     new_test_ext().execute_with(|| {
         Dex::create_exchange(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             LIQ_TOKEN_B,
             INIT_LIQUIDITY,
@@ -1290,7 +1290,7 @@ fn asset_to_asset_min_bought_tokens_too_high() {
         .unwrap();
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedInput {
@@ -1309,7 +1309,7 @@ fn asset_to_asset_min_bought_tokens_too_high() {
 fn asset_to_asset_max_sold_tokens_too_low() {
     new_test_ext().execute_with(|| {
         Dex::create_exchange(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             LIQ_TOKEN_B,
             INIT_LIQUIDITY,
@@ -1318,7 +1318,7 @@ fn asset_to_asset_max_sold_tokens_too_low() {
         .unwrap();
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedOutput {
@@ -1337,7 +1337,7 @@ fn asset_to_asset_max_sold_tokens_too_low() {
 fn asset_to_asset_not_enough_liquidity() {
     new_test_ext().execute_with(|| {
         Dex::create_exchange(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             LIQ_TOKEN_B,
             INIT_LIQUIDITY,
@@ -1346,7 +1346,7 @@ fn asset_to_asset_not_enough_liquidity() {
         .unwrap();
         assert_noop!(
             Dex::asset_to_asset(
-                Origin::signed(ACCOUNT_B),
+                RuntimeOrigin::signed(ACCOUNT_B),
                 ASSET_A,
                 ASSET_B,
                 TradeAmount::FixedOutput {
@@ -1365,7 +1365,7 @@ fn asset_to_asset_not_enough_liquidity() {
 fn asset_to_asset_transfer() {
     new_test_ext().execute_with(|| {
         Dex::create_exchange(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             LIQ_TOKEN_B,
             INIT_LIQUIDITY,
@@ -1378,7 +1378,7 @@ fn asset_to_asset_transfer() {
         let bought_token_amount = 496; // currency amount (498) - provider fee (0.3%) should be ~496
 
         assert_ok!(Dex::asset_to_asset(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             ASSET_B,
             TradeAmount::FixedInput {
@@ -1425,7 +1425,7 @@ fn asset_to_asset_transfer() {
 fn asset_to_asset_fixed_output() {
     new_test_ext().execute_with(|| {
         Dex::create_exchange(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             LIQ_TOKEN_B,
             INIT_LIQUIDITY,
@@ -1438,7 +1438,7 @@ fn asset_to_asset_fixed_output() {
         let bought_token_amount = 496; // currency amount (498) - provider fee (0.3%) should be ~496
 
         assert_ok!(Dex::asset_to_asset(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             ASSET_B,
             TradeAmount::FixedOutput {
@@ -1503,7 +1503,7 @@ fn asset_to_asset_fixed_output() {
 fn trade_assets_back_and_forth() {
     new_test_ext().execute_with(|| {
         Dex::create_exchange(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             LIQ_TOKEN_B,
             INIT_LIQUIDITY,
@@ -1517,7 +1517,7 @@ fn trade_assets_back_and_forth() {
 
         // Trade back and forth A -> B -> A
         assert_ok!(Dex::asset_to_asset(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_A,
             ASSET_B,
             TradeAmount::FixedOutput {
@@ -1528,7 +1528,7 @@ fn trade_assets_back_and_forth() {
             None
         ));
         assert_ok!(Dex::asset_to_asset(
-            Origin::signed(ACCOUNT_B),
+            RuntimeOrigin::signed(ACCOUNT_B),
             ASSET_B,
             ASSET_A,
             TradeAmount::FixedOutput {
@@ -1541,7 +1541,7 @@ fn trade_assets_back_and_forth() {
 
         // Remove all liquidity
         assert_ok!(Dex::remove_liquidity(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_A,
             INIT_LIQUIDITY,
             INIT_LIQUIDITY,
@@ -1549,7 +1549,7 @@ fn trade_assets_back_and_forth() {
             1,
         ));
         assert_ok!(Dex::remove_liquidity(
-            Origin::signed(ACCOUNT_A),
+            RuntimeOrigin::signed(ACCOUNT_A),
             ASSET_B,
             INIT_LIQUIDITY,
             INIT_LIQUIDITY,

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -53,53 +53,53 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:1 w:1)
 	// Storage: Assets Account (r:3 w:3)
 	fn create_exchange() -> Weight {
-		(103_019_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+		Weight::from_ref_time(103_019_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(7 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:3 w:3)
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn add_liquidity() -> Weight {
-		(89_032_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+		Weight::from_ref_time(89_032_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(7 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:3 w:3)
 	// Storage: System Account (r:1 w:1)
 	fn remove_liquidity() -> Weight {
-		(88_652_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
+		Weight::from_ref_time(88_652_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(7 as u64))
+			.saturating_add(T::DbWeight::get().writes(7 as u64))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:2 w:2)
 	fn currency_to_asset() -> Weight {
-		(70_294_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+		Weight::from_ref_time(70_294_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	fn asset_to_currency() -> Weight {
-		(72_349_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(5 as Weight))
+		Weight::from_ref_time(72_349_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(5 as u64))
+			.saturating_add(T::DbWeight::get().writes(5 as u64))
 	}
 	// Storage: Dex Exchanges (r:2 w:2)
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:4 w:4)
 	fn asset_to_asset() -> Weight {
-		(99_152_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+		Weight::from_ref_time(99_152_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(8 as u64))
+			.saturating_add(T::DbWeight::get().writes(8 as u64))
 	}
 }
 
@@ -110,52 +110,52 @@ impl WeightInfo for () {
 	// Storage: System Account (r:1 w:1)
 	// Storage: Assets Account (r:3 w:3)
 	fn create_exchange() -> Weight {
-		(103_019_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
+		Weight::from_ref_time(103_019_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(7 as u64))
+			.saturating_add(RocksDbWeight::get().writes(7 as u64))
 	}
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:3 w:3)
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn add_liquidity() -> Weight {
-		(89_032_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
+		Weight::from_ref_time(89_032_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(7 as u64))
+			.saturating_add(RocksDbWeight::get().writes(7 as u64))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:3 w:3)
 	// Storage: System Account (r:1 w:1)
 	fn remove_liquidity() -> Weight {
-		(88_652_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
+		Weight::from_ref_time(88_652_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(7 as u64))
+			.saturating_add(RocksDbWeight::get().writes(7 as u64))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:2 w:2)
 	fn currency_to_asset() -> Weight {
-		(70_294_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
+		Weight::from_ref_time(70_294_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(5 as u64))
+			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	fn asset_to_currency() -> Weight {
-		(72_349_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
+		Weight::from_ref_time(72_349_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(5 as u64))
+			.saturating_add(RocksDbWeight::get().writes(5 as u64))
 	}
 	// Storage: Dex Exchanges (r:2 w:2)
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:4 w:4)
 	fn asset_to_asset() -> Weight {
-		(99_152_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(8 as Weight))
+		Weight::from_ref_time(99_152_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(8 as u64))
+			.saturating_add(RocksDbWeight::get().writes(8 as u64))
 	}
 }

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -53,53 +53,53 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:1 w:1)
 	// Storage: Assets Account (r:3 w:3)
 	fn create_exchange() -> Weight {
-		Weight::from_ref_time(103_019_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(7 as u64))
-			.saturating_add(T::DbWeight::get().writes(7 as u64))
+		Weight::from_ref_time(103_019_000)
+			.saturating_add(T::DbWeight::get().reads(7))
+			.saturating_add(T::DbWeight::get().writes(7))
 	}
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:3 w:3)
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn add_liquidity() -> Weight {
-		Weight::from_ref_time(89_032_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(7 as u64))
-			.saturating_add(T::DbWeight::get().writes(7 as u64))
+		Weight::from_ref_time(89_032_000)
+			.saturating_add(T::DbWeight::get().reads(7))
+			.saturating_add(T::DbWeight::get().writes(7))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:3 w:3)
 	// Storage: System Account (r:1 w:1)
 	fn remove_liquidity() -> Weight {
-		Weight::from_ref_time(88_652_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(7 as u64))
-			.saturating_add(T::DbWeight::get().writes(7 as u64))
+		Weight::from_ref_time(88_652_000)
+			.saturating_add(T::DbWeight::get().reads(7))
+			.saturating_add(T::DbWeight::get().writes(7))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:2 w:2)
 	fn currency_to_asset() -> Weight {
-		Weight::from_ref_time(70_294_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(5 as u64))
-			.saturating_add(T::DbWeight::get().writes(5 as u64))
+		Weight::from_ref_time(70_294_000)
+			.saturating_add(T::DbWeight::get().reads(5))
+			.saturating_add(T::DbWeight::get().writes(5))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	fn asset_to_currency() -> Weight {
-		Weight::from_ref_time(72_349_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(5 as u64))
-			.saturating_add(T::DbWeight::get().writes(5 as u64))
+		Weight::from_ref_time(72_349_000)
+			.saturating_add(T::DbWeight::get().reads(5))
+			.saturating_add(T::DbWeight::get().writes(5))
 	}
 	// Storage: Dex Exchanges (r:2 w:2)
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:4 w:4)
 	fn asset_to_asset() -> Weight {
-		Weight::from_ref_time(99_152_000 as u64)
-			.saturating_add(T::DbWeight::get().reads(8 as u64))
-			.saturating_add(T::DbWeight::get().writes(8 as u64))
+		Weight::from_ref_time(99_152_000)
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(8))
 	}
 }
 
@@ -110,52 +110,52 @@ impl WeightInfo for () {
 	// Storage: System Account (r:1 w:1)
 	// Storage: Assets Account (r:3 w:3)
 	fn create_exchange() -> Weight {
-		Weight::from_ref_time(103_019_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(7 as u64))
-			.saturating_add(RocksDbWeight::get().writes(7 as u64))
+		Weight::from_ref_time(103_019_000)
+			.saturating_add(RocksDbWeight::get().reads(7))
+			.saturating_add(RocksDbWeight::get().writes(7))
 	}
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:3 w:3)
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn add_liquidity() -> Weight {
-		Weight::from_ref_time(89_032_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(7 as u64))
-			.saturating_add(RocksDbWeight::get().writes(7 as u64))
+		Weight::from_ref_time(89_032_000)
+			.saturating_add(RocksDbWeight::get().reads(7))
+			.saturating_add(RocksDbWeight::get().writes(7))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:3 w:3)
 	// Storage: System Account (r:1 w:1)
 	fn remove_liquidity() -> Weight {
-		Weight::from_ref_time(88_652_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(7 as u64))
-			.saturating_add(RocksDbWeight::get().writes(7 as u64))
+		Weight::from_ref_time(88_652_000)
+			.saturating_add(RocksDbWeight::get().reads(7))
+			.saturating_add(RocksDbWeight::get().writes(7))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:2 w:2)
 	fn currency_to_asset() -> Weight {
-		Weight::from_ref_time(70_294_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(5 as u64))
-			.saturating_add(RocksDbWeight::get().writes(5 as u64))
+		Weight::from_ref_time(70_294_000)
+			.saturating_add(RocksDbWeight::get().reads(5))
+			.saturating_add(RocksDbWeight::get().writes(5))
 	}
 	// Storage: Dex Exchanges (r:1 w:1)
 	// Storage: Assets Asset (r:1 w:1)
 	// Storage: Assets Account (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	fn asset_to_currency() -> Weight {
-		Weight::from_ref_time(72_349_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(5 as u64))
-			.saturating_add(RocksDbWeight::get().writes(5 as u64))
+		Weight::from_ref_time(72_349_000)
+			.saturating_add(RocksDbWeight::get().reads(5))
+			.saturating_add(RocksDbWeight::get().writes(5))
 	}
 	// Storage: Dex Exchanges (r:2 w:2)
 	// Storage: Assets Asset (r:2 w:2)
 	// Storage: Assets Account (r:4 w:4)
 	fn asset_to_asset() -> Weight {
-		Weight::from_ref_time(99_152_000 as u64)
-			.saturating_add(RocksDbWeight::get().reads(8 as u64))
-			.saturating_add(RocksDbWeight::get().writes(8 as u64))
+		Weight::from_ref_time(99_152_000)
+			.saturating_add(RocksDbWeight::get().reads(8))
+			.saturating_add(RocksDbWeight::get().writes(8))
 	}
 }


### PR DESCRIPTION
- updated dependencies to `polkadot-v0.9.30`, applying changes based on conventions used in Substrate
  - `Call` -> `RuntimeCall` 
  - `Event` -> `RuntimeEvent`
  - `Origin` -> `RuntimeOrigin`
  - weights using `Weight::from_ref_time` and `u64`
- integrated into substrate-node-template (v0.9.30) to verify changes
- updated readme based on changes