### PR TITLE
Changed the confusing naming taken from Uniswap code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ prices by custom RPC methods (see [RPC](#rpc) section).
 * **Currency** – The chain's main currency/token (e.g. DOT for the relay chain, ACA for Acala).
 * **Exchange** – A liquidity pool containing certain amount of an asset, and certain amount of currency. It allows users
 to swap this particular asset for currency or vice versa. The asset price (i.e. exchange rate) is established dynamically
-based on the currency-to-asset ratio.
+using the [constant product formula](https://docs.uniswap.org/contracts/v2/concepts/protocol-overview/glossary#constant-product-formula).
 * **Liquidity provider** – An account which deposits certain amount of asset and currency into an exchange.
   Providers are incentivized by receiving a fee (percentage of all transactions) paid by traders.
 * **Liquidity token** – A transferable, fungible token representing an account's share in a particular liquidity pool.
@@ -225,9 +225,9 @@ Emit two events on success: `AssetTradedForCurrency` and `CurrencyTradedForAsset
 ## RPC
 
 <details>
-<summary><h3>get_currency_to_asset_input_price</h3></summary>
+<summary><h3>get_currency_to_asset_output_amount</h3></summary>
 
-Get the price for a fixed-input currency-to-asset trade,
+Get the output amount for a fixed-input currency-to-asset trade,
 i.e. 'How much asset would I get if I paid this much currency'?
 
 #### Parameters:
@@ -236,9 +236,9 @@ i.e. 'How much asset would I get if I paid this much currency'?
 </details>
 
 <details>
-<summary><h3>get_currency_to_asset_output_price</h3></summary>
+<summary><h3>get_currency_to_asset_input_amount</h3></summary>
 
-Get the price for a fixed-output currency-to-asset trade,
+Get the input amount for a fixed-output currency-to-asset trade,
 i.e. 'How much currency do I have to pay to get this much asset'?
 
 #### Parameters:
@@ -247,9 +247,9 @@ i.e. 'How much currency do I have to pay to get this much asset'?
 </details>
 
 <details>
-<summary><h3>get_asset_to_currency_input_price</h3></summary>
+<summary><h3>get_asset_to_currency_output_amount</h3></summary>
 
-Get the price for a fixed-input asset-to-currency trade,
+Get the output amount for a fixed-input asset-to-currency trade,
 i.e. 'How much currency would I get if I paid this much asset'?
 
 #### Parameters:
@@ -258,8 +258,8 @@ i.e. 'How much currency would I get if I paid this much asset'?
 </details>
 
 <details>
-<summary><h3>get_asset_to_currency_output_price</h3></summary>
-Get the price for a fixed-output currency-to-asset trade,
+<summary><h3>get_asset_to_currency_input_amount</h3></summary>
+Get the input amount for a fixed-output currency-to-asset trade,
 i.e. 'How much asset do I have to pay to get this much currency'?
 
 #### Parameters:
@@ -405,32 +405,32 @@ Add the RPC implementation.
 impl_runtime_apis! {
     // --snip--
     impl pallet_dex_rpc_runtime_api::DexApi<Block, AssetId, Balance, AssetBalance> for Runtime {
-        fn get_currency_to_asset_input_price(
+        fn get_currency_to_asset_output_amount(
             asset_id: AssetId,
             currency_amount: Balance
         ) -> pallet_dex_rpc_runtime_api::RpcResult<AssetBalance> {
-            Dex::get_currency_to_asset_input_price(asset_id, currency_amount)
+            Dex::get_currency_to_asset_output_amount(asset_id, currency_amount)
         }
 
-        fn get_currency_to_asset_output_price(
+        fn get_currency_to_asset_input_amount(
             asset_id: AssetId,
             token_amount: AssetBalance
         ) -> pallet_dex_rpc_runtime_api::RpcResult<Balance> {
-            Dex::get_currency_to_asset_output_price(asset_id, token_amount)
+            Dex::get_currency_to_asset_input_amount(asset_id, token_amount)
         }
 
-        fn get_asset_to_currency_input_price(
+        fn get_asset_to_currency_output_amount(
             asset_id: AssetId,
             token_amount: AssetBalance
         ) -> pallet_dex_rpc_runtime_api::RpcResult<Balance> {
-            Dex::get_asset_to_currency_input_price(asset_id, token_amount)
+            Dex::get_asset_to_currency_output_amount(asset_id, token_amount)
         }
 
-        fn get_asset_to_currency_output_price(
+        fn get_asset_to_currency_input_amount(
             asset_id: AssetId,
             currency_amount: Balance
         ) -> pallet_dex_rpc_runtime_api::RpcResult<AssetBalance> {
-            Dex::get_asset_to_currency_output_price(asset_id, currency_amount)
+            Dex::get_asset_to_currency_input_amount(asset_id, currency_amount)
         }
     }
 }

--- a/rpc/runtime-api/src/lib.rs
+++ b/rpc/runtime-api/src/lib.rs
@@ -10,9 +10,9 @@ sp_api::decl_runtime_apis! {
         Balance: Codec + MaybeDisplay,
         AssetBalance: Codec + MaybeDisplay,
     {
-        fn get_currency_to_asset_input_price(asset_id: AssetId, currency_amount: Balance) -> RpcResult<AssetBalance>;
-        fn get_currency_to_asset_output_price(asset_id: AssetId, token_amount: AssetBalance) -> RpcResult<Balance>;
-        fn get_asset_to_currency_input_price(asset_id: AssetId, token_amount: AssetBalance) -> RpcResult<Balance>;
-        fn get_asset_to_currency_output_price(asset_id: AssetId, currency_amount: Balance) -> RpcResult<AssetBalance>;
+        fn get_currency_to_asset_output_amount(asset_id: AssetId, currency_amount: Balance) -> RpcResult<AssetBalance>;
+        fn get_currency_to_asset_input_amount(asset_id: AssetId, token_amount: AssetBalance) -> RpcResult<Balance>;
+        fn get_asset_to_currency_output_amount(asset_id: AssetId, token_amount: AssetBalance) -> RpcResult<Balance>;
+        fn get_asset_to_currency_input_amount(asset_id: AssetId, currency_amount: Balance) -> RpcResult<AssetBalance>;
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -24,32 +24,32 @@ mod tests;
 
 #[rpc(client, server)]
 pub trait DexApi<BlockHash, AssetId, Balance, AssetBalance> {
-    #[method(name = "dex_get_currency_to_asset_input_price")]
-    fn get_currency_to_asset_input_price(
+    #[method(name = "dex_get_currency_to_asset_output_amount")]
+    fn get_currency_to_asset_output_amount(
         &self,
         asset_id: AssetId,
         currency_amount: Balance,
         at: Option<BlockHash>,
     ) -> RpcResult<AssetBalance>;
 
-    #[method(name = "dex_get_currency_to_asset_output_price")]
-    fn get_currency_to_asset_output_price(
+    #[method(name = "dex_get_currency_to_asset_input_amount")]
+    fn get_currency_to_asset_input_amount(
         &self,
         asset_id: AssetId,
         token_amount: AssetBalance,
         at: Option<BlockHash>,
     ) -> RpcResult<Balance>;
 
-    #[method(name = "dex_get_asset_to_currency_input_price")]
-    fn get_asset_to_currency_input_price(
+    #[method(name = "dex_get_asset_to_currency_output_amount")]
+    fn get_asset_to_currency_output_amount(
         &self,
         asset_id: AssetId,
         token_amount: AssetBalance,
         at: Option<BlockHash>,
     ) -> RpcResult<Balance>;
 
-    #[method(name = "dex_get_asset_to_currency_output_price")]
-    fn get_asset_to_currency_output_price(
+    #[method(name = "dex_get_asset_to_currency_input_amount")]
+    fn get_asset_to_currency_input_amount(
         &self,
         asset_id: AssetId,
         currency_amount: Balance,
@@ -95,7 +95,7 @@ where
     Balance: Codec + MaybeDisplay + Copy + Send + Sync + 'static,
     AssetBalance: Codec + MaybeDisplay + Copy + Send + Sync + 'static,
 {
-    fn get_currency_to_asset_input_price(
+    fn get_currency_to_asset_output_amount(
         &self,
         asset_id: AssetId,
         currency_amount: Balance,
@@ -104,12 +104,12 @@ where
         let at = self.block_id(at);
         self.client
             .runtime_api()
-            .get_currency_to_asset_input_price(&at, asset_id, currency_amount)
+            .get_currency_to_asset_output_amount(&at, asset_id, currency_amount)
             .map_err(runtime_error)?
             .map_err(dex_rpc_error)
     }
 
-    fn get_currency_to_asset_output_price(
+    fn get_currency_to_asset_input_amount(
         &self,
         asset_id: AssetId,
         token_amount: AssetBalance,
@@ -118,12 +118,12 @@ where
         let at = self.block_id(at);
         self.client
             .runtime_api()
-            .get_currency_to_asset_output_price(&at, asset_id, token_amount)
+            .get_currency_to_asset_input_amount(&at, asset_id, token_amount)
             .map_err(runtime_error)?
             .map_err(dex_rpc_error)
     }
 
-    fn get_asset_to_currency_input_price(
+    fn get_asset_to_currency_output_amount(
         &self,
         asset_id: AssetId,
         token_amount: AssetBalance,
@@ -132,12 +132,12 @@ where
         let at = self.block_id(at);
         self.client
             .runtime_api()
-            .get_asset_to_currency_input_price(&at, asset_id, token_amount)
+            .get_asset_to_currency_output_amount(&at, asset_id, token_amount)
             .map_err(runtime_error)?
             .map_err(dex_rpc_error)
     }
 
-    fn get_asset_to_currency_output_price(
+    fn get_asset_to_currency_input_amount(
         &self,
         asset_id: AssetId,
         currency_amount: Balance,
@@ -146,7 +146,7 @@ where
         let at = self.block_id(at);
         self.client
             .runtime_api()
-            .get_asset_to_currency_output_price(&at, asset_id, currency_amount)
+            .get_asset_to_currency_input_amount(&at, asset_id, currency_amount)
             .map_err(runtime_error)?
             .map_err(dex_rpc_error)
     }

--- a/rpc/src/tests.rs
+++ b/rpc/src/tests.rs
@@ -27,8 +27,8 @@ fn assert(error: Error, code: i32, message: &str, data: Option<&[u8]>) {
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_input_price_with_exchange_not_found() {
-    let expectation = Expectation::GetCurrencyToAssetInputPrice(
+async fn get_currency_to_asset_output_amount_with_exchange_not_found() {
+    let expectation = Expectation::GetCurrencyToAssetOutputAmount(
         ASSET,
         CURRENCY_AMOUNT,
         Err(RpcError::ExchangeNotFound),
@@ -37,15 +37,15 @@ async fn get_currency_to_asset_input_price_with_exchange_not_found() {
     let api = Dex::new(client);
 
     let error = api
-        .get_currency_to_asset_input_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_currency_to_asset_output_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap_err();
 
     assert(error, EXCHANGE_NOT_FOUND, EXCHANGE_NOT_FOUND_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_input_price_with_not_enough_liquidity() {
-    let expectation = Expectation::GetCurrencyToAssetInputPrice(
+async fn get_currency_to_asset_output_amount_with_not_enough_liquidity() {
+    let expectation = Expectation::GetCurrencyToAssetOutputAmount(
         ASSET,
         CURRENCY_AMOUNT,
         Err(RpcError::NotEnoughLiquidity),
@@ -54,29 +54,32 @@ async fn get_currency_to_asset_input_price_with_not_enough_liquidity() {
     let api = Dex::new(client);
 
     let error = api
-        .get_currency_to_asset_input_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_currency_to_asset_output_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap_err();
 
     assert(error, NOT_ENOUGH_LIQUIDITY, NOT_ENOUGH_LIQUIDITY_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_input_price_with_overflow() {
-    let expectation =
-        Expectation::GetCurrencyToAssetInputPrice(ASSET, CURRENCY_AMOUNT, Err(RpcError::Overflow));
+async fn get_currency_to_asset_output_amount_with_overflow() {
+    let expectation = Expectation::GetCurrencyToAssetOutputAmount(
+        ASSET,
+        CURRENCY_AMOUNT,
+        Err(RpcError::Overflow),
+    );
     let client = Arc::new(TestApi::new(expectation));
     let api = Dex::new(client);
 
     let error = api
-        .get_currency_to_asset_input_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_currency_to_asset_output_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap_err();
 
     assert(error, OVERFLOW, OVERFLOW_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_input_price_with_unexpected() {
-    let expectation = Expectation::GetCurrencyToAssetInputPrice(
+async fn get_currency_to_asset_output_amount_with_unexpected() {
+    let expectation = Expectation::GetCurrencyToAssetOutputAmount(
         ASSET,
         CURRENCY_AMOUNT,
         Err(RpcError::Unexpected(DATA.into())),
@@ -85,29 +88,29 @@ async fn get_currency_to_asset_input_price_with_unexpected() {
     let api = Dex::new(client);
 
     let error = api
-        .get_currency_to_asset_input_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_currency_to_asset_output_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap_err();
 
     assert(error, RUNTIME_ERROR, RUNTIME_ERROR_MESSAGE, Some(&DATA))
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_input_price_with_success() {
-    let expectation = Expectation::GetCurrencyToAssetInputPrice(ASSET, CURRENCY_AMOUNT, Ok(100));
+async fn get_currency_to_asset_output_amount_with_success() {
+    let expectation = Expectation::GetCurrencyToAssetOutputAmount(ASSET, CURRENCY_AMOUNT, Ok(100));
 
     let client = Arc::new(TestApi::new(expectation));
     let api = Dex::new(client);
 
     let result = api
-        .get_currency_to_asset_input_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_currency_to_asset_output_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap();
 
     assert_eq!(100, result);
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_output_price_with_exchange_not_found() {
-    let expectation = Expectation::GetCurrencyToAssetOutputPrice(
+async fn get_currency_to_asset_input_amount_with_exchange_not_found() {
+    let expectation = Expectation::GetCurrencyToAssetInputAmount(
         ASSET,
         TOKEN_AMOUNT,
         Err(RpcError::ExchangeNotFound),
@@ -116,15 +119,15 @@ async fn get_currency_to_asset_output_price_with_exchange_not_found() {
     let api = Dex::new(client);
 
     let error = api
-        .get_currency_to_asset_output_price(ASSET, TOKEN_AMOUNT, None)
+        .get_currency_to_asset_input_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap_err();
 
     assert(error, EXCHANGE_NOT_FOUND, EXCHANGE_NOT_FOUND_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_output_price_with_not_enough_liquidity() {
-    let expectation = Expectation::GetCurrencyToAssetOutputPrice(
+async fn get_currency_to_asset_input_amount_with_not_enough_liquidity() {
+    let expectation = Expectation::GetCurrencyToAssetInputAmount(
         ASSET,
         TOKEN_AMOUNT,
         Err(RpcError::NotEnoughLiquidity),
@@ -133,29 +136,29 @@ async fn get_currency_to_asset_output_price_with_not_enough_liquidity() {
     let api = Dex::new(client);
 
     let error = api
-        .get_currency_to_asset_output_price(ASSET, TOKEN_AMOUNT, None)
+        .get_currency_to_asset_input_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap_err();
 
     assert(error, NOT_ENOUGH_LIQUIDITY, NOT_ENOUGH_LIQUIDITY_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_output_price_with_overflow() {
+async fn get_currency_to_asset_input_amount_with_overflow() {
     let expectation =
-        Expectation::GetCurrencyToAssetOutputPrice(ASSET, TOKEN_AMOUNT, Err(RpcError::Overflow));
+        Expectation::GetCurrencyToAssetInputAmount(ASSET, TOKEN_AMOUNT, Err(RpcError::Overflow));
     let client = Arc::new(TestApi::new(expectation));
     let api = Dex::new(client);
 
     let error = api
-        .get_currency_to_asset_output_price(ASSET, TOKEN_AMOUNT, None)
+        .get_currency_to_asset_input_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap_err();
 
     assert(error, OVERFLOW, OVERFLOW_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_output_price_with_unexpected() {
-    let expectation = Expectation::GetCurrencyToAssetOutputPrice(
+async fn get_currency_to_asset_input_amount_with_unexpected() {
+    let expectation = Expectation::GetCurrencyToAssetInputAmount(
         ASSET,
         TOKEN_AMOUNT,
         Err(RpcError::Unexpected(DATA.into())),
@@ -164,29 +167,29 @@ async fn get_currency_to_asset_output_price_with_unexpected() {
     let api = Dex::new(client);
 
     let error = api
-        .get_currency_to_asset_output_price(ASSET, TOKEN_AMOUNT, None)
+        .get_currency_to_asset_input_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap_err();
 
     assert(error, RUNTIME_ERROR, RUNTIME_ERROR_MESSAGE, Some(&DATA))
 }
 
 #[tokio::test]
-async fn get_currency_to_asset_output_price_with_success() {
-    let expectation = Expectation::GetCurrencyToAssetOutputPrice(ASSET, TOKEN_AMOUNT, Ok(100));
+async fn get_currency_to_asset_input_amount_with_success() {
+    let expectation = Expectation::GetCurrencyToAssetInputAmount(ASSET, TOKEN_AMOUNT, Ok(100));
 
     let client = Arc::new(TestApi::new(expectation));
     let api = Dex::new(client);
 
     let result = api
-        .get_currency_to_asset_output_price(ASSET, TOKEN_AMOUNT, None)
+        .get_currency_to_asset_input_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap();
 
     assert_eq!(100, result);
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_input_price_with_exchange_not_found() {
-    let expectation = Expectation::GetAssetToCurrencyInputPrice(
+async fn get_asset_to_currency_output_amount_with_exchange_not_found() {
+    let expectation = Expectation::GetAssetToCurrencyOutputAmount(
         ASSET,
         TOKEN_AMOUNT,
         Err(RpcError::ExchangeNotFound),
@@ -195,15 +198,15 @@ async fn get_asset_to_currency_input_price_with_exchange_not_found() {
     let api = Dex::new(client);
 
     let error = api
-        .get_asset_to_currency_input_price(ASSET, TOKEN_AMOUNT, None)
+        .get_asset_to_currency_output_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap_err();
 
     assert(error, EXCHANGE_NOT_FOUND, EXCHANGE_NOT_FOUND_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_input_price_with_not_enough_liquidity() {
-    let expectation = Expectation::GetAssetToCurrencyInputPrice(
+async fn get_asset_to_currency_output_amount_with_not_enough_liquidity() {
+    let expectation = Expectation::GetAssetToCurrencyOutputAmount(
         ASSET,
         TOKEN_AMOUNT,
         Err(RpcError::NotEnoughLiquidity),
@@ -212,29 +215,29 @@ async fn get_asset_to_currency_input_price_with_not_enough_liquidity() {
     let api = Dex::new(client);
 
     let error = api
-        .get_asset_to_currency_input_price(ASSET, TOKEN_AMOUNT, None)
+        .get_asset_to_currency_output_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap_err();
 
     assert(error, NOT_ENOUGH_LIQUIDITY, NOT_ENOUGH_LIQUIDITY_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_input_price_with_overflow() {
+async fn get_asset_to_currency_output_amount_with_overflow() {
     let expectation =
-        Expectation::GetAssetToCurrencyInputPrice(ASSET, TOKEN_AMOUNT, Err(RpcError::Overflow));
+        Expectation::GetAssetToCurrencyOutputAmount(ASSET, TOKEN_AMOUNT, Err(RpcError::Overflow));
     let client = Arc::new(TestApi::new(expectation));
     let api = Dex::new(client);
 
     let error = api
-        .get_asset_to_currency_input_price(ASSET, TOKEN_AMOUNT, None)
+        .get_asset_to_currency_output_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap_err();
 
     assert(error, OVERFLOW, OVERFLOW_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_input_price_with_unexpected() {
-    let expectation = Expectation::GetAssetToCurrencyInputPrice(
+async fn get_asset_to_currency_output_amount_with_unexpected() {
+    let expectation = Expectation::GetAssetToCurrencyOutputAmount(
         ASSET,
         TOKEN_AMOUNT,
         Err(RpcError::Unexpected(DATA.into())),
@@ -243,29 +246,29 @@ async fn get_asset_to_currency_input_price_with_unexpected() {
     let api = Dex::new(client);
 
     let error = api
-        .get_asset_to_currency_input_price(ASSET, TOKEN_AMOUNT, None)
+        .get_asset_to_currency_output_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap_err();
 
     assert(error, RUNTIME_ERROR, RUNTIME_ERROR_MESSAGE, Some(&DATA))
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_input_price_with_success() {
-    let expectation = Expectation::GetAssetToCurrencyInputPrice(ASSET, TOKEN_AMOUNT, Ok(100));
+async fn get_asset_to_currency_output_amount_with_success() {
+    let expectation = Expectation::GetAssetToCurrencyOutputAmount(ASSET, TOKEN_AMOUNT, Ok(100));
 
     let client = Arc::new(TestApi::new(expectation));
     let api = Dex::new(client);
 
     let result = api
-        .get_asset_to_currency_input_price(ASSET, TOKEN_AMOUNT, None)
+        .get_asset_to_currency_output_amount(ASSET, TOKEN_AMOUNT, None)
         .unwrap();
 
     assert_eq!(100, result);
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_output_price_with_exchange_not_found() {
-    let expectation = Expectation::GetAssetToCurrencyOutputPrice(
+async fn get_asset_to_currency_input_amount_with_exchange_not_found() {
+    let expectation = Expectation::GetAssetToCurrencyInputAmount(
         ASSET,
         CURRENCY_AMOUNT,
         Err(RpcError::ExchangeNotFound),
@@ -274,15 +277,15 @@ async fn get_asset_to_currency_output_price_with_exchange_not_found() {
     let api = Dex::new(client);
 
     let error = api
-        .get_asset_to_currency_output_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_asset_to_currency_input_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap_err();
 
     assert(error, EXCHANGE_NOT_FOUND, EXCHANGE_NOT_FOUND_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_output_price_with_not_enough_liquidity() {
-    let expectation = Expectation::GetAssetToCurrencyOutputPrice(
+async fn get_asset_to_currency_input_amount_with_not_enough_liquidity() {
+    let expectation = Expectation::GetAssetToCurrencyInputAmount(
         ASSET,
         CURRENCY_AMOUNT,
         Err(RpcError::NotEnoughLiquidity),
@@ -291,29 +294,29 @@ async fn get_asset_to_currency_output_price_with_not_enough_liquidity() {
     let api = Dex::new(client);
 
     let error = api
-        .get_asset_to_currency_output_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_asset_to_currency_input_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap_err();
 
     assert(error, NOT_ENOUGH_LIQUIDITY, NOT_ENOUGH_LIQUIDITY_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_output_price_with_overflow() {
+async fn get_asset_to_currency_input_amount_with_overflow() {
     let expectation =
-        Expectation::GetAssetToCurrencyOutputPrice(ASSET, CURRENCY_AMOUNT, Err(RpcError::Overflow));
+        Expectation::GetAssetToCurrencyInputAmount(ASSET, CURRENCY_AMOUNT, Err(RpcError::Overflow));
     let client = Arc::new(TestApi::new(expectation));
     let api = Dex::new(client);
 
     let error = api
-        .get_asset_to_currency_output_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_asset_to_currency_input_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap_err();
 
     assert(error, OVERFLOW, OVERFLOW_MESSAGE, None)
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_output_price_with_unexpected() {
-    let expectation = Expectation::GetAssetToCurrencyOutputPrice(
+async fn get_asset_to_currency_input_amount_with_unexpected() {
+    let expectation = Expectation::GetAssetToCurrencyInputAmount(
         ASSET,
         CURRENCY_AMOUNT,
         Err(RpcError::Unexpected(DATA.into())),
@@ -322,21 +325,21 @@ async fn get_asset_to_currency_output_price_with_unexpected() {
     let api = Dex::new(client);
 
     let error = api
-        .get_asset_to_currency_output_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_asset_to_currency_input_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap_err();
 
     assert(error, RUNTIME_ERROR, RUNTIME_ERROR_MESSAGE, Some(&DATA))
 }
 
 #[tokio::test]
-async fn get_asset_to_currency_output_price_with_success() {
-    let expectation = Expectation::GetAssetToCurrencyOutputPrice(ASSET, CURRENCY_AMOUNT, Ok(100));
+async fn get_asset_to_currency_input_amount_with_success() {
+    let expectation = Expectation::GetAssetToCurrencyInputAmount(ASSET, CURRENCY_AMOUNT, Ok(100));
 
     let client = Arc::new(TestApi::new(expectation));
     let api = Dex::new(client);
 
     let result = api
-        .get_asset_to_currency_output_price(ASSET, CURRENCY_AMOUNT, None)
+        .get_asset_to_currency_input_amount(ASSET, CURRENCY_AMOUNT, None)
         .unwrap();
 
     assert_eq!(100, result);
@@ -424,33 +427,33 @@ mod mock {
     sp_api::mock_impl_runtime_apis! {
         // A simple mock implementation to compare provided values with expected
         impl DexRuntimeApi<Block, AssetId, Balance, AssetBalance> for TestRuntimeApi {
-            fn get_currency_to_asset_input_price(asset_id: AssetId, currency_amount: Balance) -> RpcResult<AssetBalance> {
+            fn get_currency_to_asset_output_amount(asset_id: AssetId, currency_amount: Balance) -> RpcResult<AssetBalance> {
                 match &self.call {
-                    Expectation::GetCurrencyToAssetInputPrice ( expected_asset, expected_amount, result)
+                    Expectation::GetCurrencyToAssetOutputAmount ( expected_asset, expected_amount, result)
                         if asset_id == *expected_asset && currency_amount == *expected_amount => result.clone(),
                     _ => panic!()
                 }
             }
 
-            fn get_currency_to_asset_output_price(asset_id: AssetId, token_amount: AssetBalance) -> RpcResult<Balance> {
+            fn get_currency_to_asset_input_amount(asset_id: AssetId, token_amount: AssetBalance) -> RpcResult<Balance> {
                 match &self.call {
-                    Expectation::GetCurrencyToAssetOutputPrice ( expected_asset, expected_amount, result)
+                    Expectation::GetCurrencyToAssetInputAmount ( expected_asset, expected_amount, result)
                         if asset_id == *expected_asset && token_amount == *expected_amount => result.clone(),
                     _ => panic!()
                 }
             }
 
-            fn get_asset_to_currency_input_price(asset_id: AssetId, token_amount: AssetBalance) -> RpcResult<Balance>{
+            fn get_asset_to_currency_output_amount(asset_id: AssetId, token_amount: AssetBalance) -> RpcResult<Balance>{
                 match &self.call {
-                    Expectation::GetAssetToCurrencyInputPrice ( expected_asset, expected_amount, result)
+                    Expectation::GetAssetToCurrencyOutputAmount ( expected_asset, expected_amount, result)
                         if asset_id == *expected_asset && token_amount == *expected_amount => result.clone(),
                     _ => panic!()
                 }
             }
 
-            fn get_asset_to_currency_output_price(asset_id: AssetId, currency_amount: Balance) -> RpcResult<AssetBalance>{
+            fn get_asset_to_currency_input_amount(asset_id: AssetId, currency_amount: Balance) -> RpcResult<AssetBalance>{
                 match &self.call {
-                    Expectation::GetAssetToCurrencyOutputPrice ( expected_asset, expected_amount, result)
+                    Expectation::GetAssetToCurrencyInputAmount ( expected_asset, expected_amount, result)
                         if asset_id == *expected_asset && currency_amount == *expected_amount => result.clone(),
                     _ => panic!()
                 }
@@ -461,9 +464,9 @@ mod mock {
     #[allow(clippy::enum_variant_names)]
     #[derive(PartialEq, Debug, Clone)]
     pub(crate) enum Expectation {
-        GetCurrencyToAssetInputPrice(AssetId, Balance, RpcResult<AssetBalance>),
-        GetCurrencyToAssetOutputPrice(AssetId, AssetBalance, RpcResult<Balance>),
-        GetAssetToCurrencyInputPrice(AssetId, AssetBalance, RpcResult<Balance>),
-        GetAssetToCurrencyOutputPrice(AssetId, Balance, RpcResult<AssetBalance>),
+        GetCurrencyToAssetOutputAmount(AssetId, Balance, RpcResult<AssetBalance>),
+        GetCurrencyToAssetInputAmount(AssetId, AssetBalance, RpcResult<Balance>),
+        GetAssetToCurrencyOutputAmount(AssetId, AssetBalance, RpcResult<Balance>),
+        GetAssetToCurrencyInputAmount(AssetId, Balance, RpcResult<AssetBalance>),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,7 +816,7 @@ pub mod pallet {
             }
         }
 
-        pub(crate) fn get_input_price(
+        pub(crate) fn get_output_amount(
             input_amount: &BalanceOf<T>,
             input_reserve: &BalanceOf<T>,
             output_reserve: &BalanceOf<T>,
@@ -837,7 +837,7 @@ pub mod pallet {
             Ok(numerator / denominator)
         }
 
-        pub(crate) fn get_output_price(
+        pub(crate) fn get_input_amount(
             output_amount: &BalanceOf<T>,
             input_reserve: &BalanceOf<T>,
             output_reserve: &BalanceOf<T>,
@@ -866,7 +866,7 @@ pub mod pallet {
                     input_amount: currency_amount,
                     min_output: min_tokens,
                 } => {
-                    let token_amount = Self::get_input_price(
+                    let token_amount = Self::get_output_amount(
                         &currency_amount,
                         &exchange.currency_reserve,
                         &T::asset_to_currency(exchange.token_reserve),
@@ -879,7 +879,7 @@ pub mod pallet {
                     max_input: max_currency,
                     output_amount: token_amount,
                 } => {
-                    let currency_amount = Self::get_output_price(
+                    let currency_amount = Self::get_input_amount(
                         &T::asset_to_currency(token_amount),
                         &exchange.currency_reserve,
                         &T::asset_to_currency(exchange.token_reserve),
@@ -899,7 +899,7 @@ pub mod pallet {
                     input_amount: token_amount,
                     min_output: min_currency,
                 } => {
-                    let currency_amount = Self::get_input_price(
+                    let currency_amount = Self::get_output_amount(
                         &T::asset_to_currency(token_amount),
                         &T::asset_to_currency(exchange.token_reserve),
                         &exchange.currency_reserve,
@@ -911,7 +911,7 @@ pub mod pallet {
                     max_input: max_tokens,
                     output_amount: currency_amount,
                 } => {
-                    let token_amount = Self::get_output_price(
+                    let token_amount = Self::get_input_amount(
                         &currency_amount,
                         &T::asset_to_currency(exchange.token_reserve),
                         &exchange.currency_reserve,
@@ -933,12 +933,12 @@ pub mod pallet {
                     input_amount: sold_token_amount,
                     min_output: min_bought_tokens,
                 } => {
-                    let currency_amount = Self::get_input_price(
+                    let currency_amount = Self::get_output_amount(
                         &T::asset_to_currency(sold_token_amount),
                         &T::asset_to_currency(sold_asset_exchange.token_reserve),
                         &sold_asset_exchange.currency_reserve,
                     )?;
-                    let bought_token_amount = Self::get_input_price(
+                    let bought_token_amount = Self::get_output_amount(
                         &currency_amount,
                         &bought_asset_exchange.currency_reserve,
                         &T::asset_to_currency(bought_asset_exchange.token_reserve),
@@ -954,12 +954,12 @@ pub mod pallet {
                     max_input: max_sold_tokens,
                     output_amount: bought_token_amount,
                 } => {
-                    let currency_amount = Self::get_output_price(
+                    let currency_amount = Self::get_input_amount(
                         &T::asset_to_currency(bought_token_amount),
                         &bought_asset_exchange.currency_reserve,
                         &T::asset_to_currency(bought_asset_exchange.token_reserve),
                     )?;
-                    let sold_token_amount = Self::get_output_price(
+                    let sold_token_amount = Self::get_input_amount(
                         &currency_amount,
                         &T::asset_to_currency(sold_asset_exchange.token_reserve),
                         &sold_asset_exchange.currency_reserve,


### PR DESCRIPTION
These methods do not compute a price (a ratio of asset respect to currency, e.g. units of A per unit of B) but an output or input amount.