### PR TITLE
fix jsonrpsee version

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,7 +12,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-jsonrpsee = { version = "0.15.1", features = ["server", "macros"] }
+jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
 
 pallet-dex-rpc-runtime-api = { version = "0.0.1", path = "./runtime-api" }
 


### PR DESCRIPTION
As a part of Upgrade 0.9.36, we also updated `jsonrpsee` to `0.16.2`. We forgot to update this at one place and this is causing trappist 0.9.36 compilation fail. 

As a part of this PR, we fixed this issue by upgrading `jsonrpsee` to `0.16.2`.