### PR TITLE
Upgrade 0.9.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 
-frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40", optional = true }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42", optional = true }
+frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
-pallet-assets = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+pallet-assets = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-sp-std = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+sp-std = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-core = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-io = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-core = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-io = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [features]
 default = ["std"]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -16,12 +16,12 @@ jsonrpsee = { version = "0.16.2", features = ["server", "macros"] }
 
 pallet-dex-rpc-runtime-api = { version = "0.0.1", path = "./runtime-api" }
 
-sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-blockchain = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
 pallet-dex = { version = "0.0.1", path = ".." }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.42" }
 tokio = { version = "1.21.2", features = ["macros", "time", "parking_lot"] }

--- a/rpc/runtime-api/Cargo.toml
+++ b/rpc/runtime-api/Cargo.toml
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 
 pallet-dex = { version = "0.0.1", default-features = false, path = "../.." }
-sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
-sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.40" }
+sp-api = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime = { default-features = false, version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [features]
 default = ["std"]

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -63,8 +63,8 @@ impl pallet_balances::Config for Test {
     type ReserveIdentifier = [u8; 8];
     type FreezeIdentifier = ();
     type HoldIdentifier = ();
-    type MaxFreezes = ();
-    type MaxHolds = ();
+    type MaxFreezes = ConstU32<0>;
+    type MaxHolds = ConstU32<0>;
 }
 
 impl pallet_assets::Config for Test {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -61,6 +61,10 @@ impl pallet_balances::Config for Test {
     type MaxLocks = ();
     type MaxReserves = ();
     type ReserveIdentifier = [u8; 8];
+    type FreezeIdentifier = ();
+    type HoldIdentifier = ();
+    type MaxFreezes = ();
+    type MaxHolds = ();
 }
 
 impl pallet_assets::Config for Test {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,10 +1,11 @@
 use crate::{AssetBalanceOf, AssetIdOf, BalanceOf, Config, ConfigHelper, Error, Pallet};
 use codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use scale_info::prelude::format;
 use sp_std::fmt::Debug;
 use sp_std::vec::Vec;
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub enum RpcError {
     ExchangeNotFound,
     NotEnoughLiquidity,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::mock::*;
 use crate::pallet::ConfigHelper;
 use crate::{Error, TradeAmount};
+use frame_support::traits::tokens::{Fortitude, Precision};
 use frame_support::{
     assert_noop, assert_ok,
     traits::{fungibles::Mutate, Currency},
@@ -857,7 +858,14 @@ fn asset_to_currency_not_enough_tokens() {
         let token_amount = 500;
         let min_currency = 498; // token amount (500) - provider fee (0.3%) should be ~498
 
-        <Test as crate::Config>::Assets::burn_from(ASSET_A, &ACCOUNT_B, INIT_BALANCE).unwrap();
+        <Test as crate::Config>::Assets::burn_from(
+            ASSET_A,
+            &ACCOUNT_B,
+            INIT_BALANCE,
+            Precision::Exact,
+            Fortitude::Polite,
+        )
+        .unwrap();
         assert_noop!(
             Dex::asset_to_currency(
                 RuntimeOrigin::signed(ACCOUNT_B),
@@ -1238,7 +1246,14 @@ fn asset_to_asset_not_enough_tokens() {
         // sold token amount (500) - provider fee (0.3%) should be ~498
         let bought_token_amount = 496; // currency amount (498) - provider fee (0.3%) should be ~496
 
-        <Test as crate::Config>::Assets::burn_from(ASSET_A, &ACCOUNT_B, INIT_BALANCE).unwrap();
+        <Test as crate::Config>::Assets::burn_from(
+            ASSET_A,
+            &ACCOUNT_B,
+            INIT_BALANCE,
+            Precision::Exact,
+            Fortitude::Polite,
+        )
+        .unwrap();
 
         assert_noop!(
             Dex::asset_to_asset(


### PR DESCRIPTION
Upgrades the pallet to V0.9.42, the main changes are based on the modification to the balance_pallet and the fungibles traits as described [in this PR on substrate](https://github.com/paritytech/substrate/pull/12951).

The main change has to do with the removal of the `Transfer` trait which was merged into the `Mutate` trait and the inclusion/change of some parameters to some of the functions inside this trait. For example `burn_from()` now has 2 extra parameters

```rust
T::AssetRegistry::burn_from(
    exchange.liquidity_token_id.clone(),
    &provider,
    liquidity_amount,
    Precision::Exact,   //New: precision required of an operation
    Fortitude::Polite,  //New: the privilege with which a withdraw operation is conducted.
)?;
```

closes #53 